### PR TITLE
Prevent TensorFlow from an attempt to access GPU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ script:
   - echo '-batch' > .sbtopts
   - sbt scalafmtCheck
   - sbt compile test
+
+  # Prevent TensorFlow from an attempt to access GPU
+  - export CUDA_VISIBLE_DEVICES=-1
+
   # We're keeping the number of epochs and training data size deliberately low -
   # the CI runs of the examples serve rather as smoke tests to spot linking/Python invocation errors.
   - export EPOCH_COUNT=40


### PR DESCRIPTION
Attempt to fix heisen-failing builds like https://travis-ci.org/github/VirtuslabRnD/scalapy-tensorflow/jobs/712713384

The builds are passing... but this might be by a pure chance; let's see if the error (`[error] 2020-07-28 21:29:44.279787: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory
[error] 2020-07-28 21:29:44.283458: E tensorflow/stream_executor/cuda/cuda_driver.cc:313] failed call to cuInit: UNKNOWN ERROR (303)`) still repeats after adding the flag